### PR TITLE
Add demo layout to showcase design system

### DIFF
--- a/src/app/layouts/MainLayout/index.tsx
+++ b/src/app/layouts/MainLayout/index.tsx
@@ -85,6 +85,11 @@ const MainLayout: React.FC = () => {
                   Usuarios
                 </a>
               </li>
+              <li>
+                <a href={ROUTES.demo} className={styles.navLink}>
+                  Demo
+                </a>
+              </li>
             </ul>
           </nav>
 

--- a/src/app/routes/AppRouter.tsx
+++ b/src/app/routes/AppRouter.tsx
@@ -7,6 +7,7 @@ import useAuthStore from "../../features/auth/store/authStore";
 import ProfilePage from "../../features/users/pages/ProfilePage";
 import AuthChecker from "../../features/auth/components/AuthChecker";
 import UsersPage from "../../features/users/pages/UsersPage";
+import { DemoPage } from "../../features/demo";
 
 /**
  * Componente para rutas protegidas que requieren autenticación
@@ -89,6 +90,8 @@ const AppRouter: React.FC = () => {
           <Route path={privateRoutes.profile.path} element={<ProfilePage />} />
           {/* Gestionar usuarios */}
           <Route path={privateRoutes.users.path} element={<UsersPage />} />
+          {/* Página de demostración de componentes */}
+          <Route path={privateRoutes.demo.path} element={<DemoPage />} />
           {/* Aquí se añadirán más rutas privadas */}
         </Route>
 

--- a/src/common/components/Typography/Heading.tsx
+++ b/src/common/components/Typography/Heading.tsx
@@ -1,0 +1,29 @@
+import React, { ElementType } from "react";
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+interface HeadingProps {
+  level?: HeadingLevel;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const levelClasses: Record<HeadingLevel, string> = {
+  1: "text-4xl font-bold tracking-tight",
+  2: "text-3xl font-semibold tracking-tight",
+  3: "text-2xl font-medium tracking-tight",
+  4: "text-xl font-medium",
+  5: "text-lg font-medium",
+  6: "text-base font-medium",
+};
+
+const Heading: React.FC<HeadingProps> = ({
+  level = 1,
+  className = "",
+  children,
+}) => {
+  const Component = (`h${level}` as unknown) as ElementType;
+  return <Component className={`${levelClasses[level]} ${className}`}>{children}</Component>;
+};
+
+export default Heading;

--- a/src/common/components/Typography/index.tsx
+++ b/src/common/components/Typography/index.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Heading, { HeadingLevel } from "./Heading";
+
+interface TypographyProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+const createHeading = (level: HeadingLevel) => {
+  const Component: React.FC<TypographyProps> = ({ children, className = "" }) => (
+    <Heading level={level} className={className}>
+      {children}
+    </Heading>
+  );
+  Component.displayName = `H${level}`;
+  return Component;
+};
+
+export const H1 = createHeading(1);
+export const H2 = createHeading(2);
+export const H3 = createHeading(3);
+export const H4 = createHeading(4);
+export const H5 = createHeading(5);
+export const H6 = createHeading(6);
+
+export const Text: React.FC<TypographyProps> = ({ children, className = "" }) => (
+  <p className={`text-base text-gray-300 ${className}`}>{children}</p>
+);
+
+export default Heading;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -32,6 +32,7 @@ export const ROUTES = {
   events: "/events",
   projects: "/projects",
   users: "/users",
+  demo: "/demo",
 };
 
 // Mensajes de error

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -61,6 +61,11 @@ export const privateRoutes: Record<string, RouteConfig> = {
     title: "Usuarios",
     protected: true,
   },
+  demo: {
+    path: ROUTES.demo,
+    title: "Demo",
+    protected: true,
+  },
 };
 
 // Todas las rutas combinadas

--- a/src/features/demo/components/ButtonDemo.tsx
+++ b/src/features/demo/components/ButtonDemo.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Button from "../../../common/components/Button";
+
+/**
+ * Sección de demostración de botones con sus variantes
+ */
+const ButtonDemo: React.FC = () => (
+  <section className="space-y-4">
+    <h2 className="text-2xl font-bold">Botones</h2>
+    <div className="space-x-2">
+      <Button variant="primary">Primario</Button>
+      <Button variant="secondary">Secundario</Button>
+      <Button variant="outline">Outline</Button>
+      <Button variant="text">Texto</Button>
+      <Button variant="danger">Peligro</Button>
+    </div>
+  </section>
+);
+
+export default ButtonDemo;

--- a/src/features/demo/components/FormDemo.tsx
+++ b/src/features/demo/components/FormDemo.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Form, FormField, FormRow, FormActions } from "../../../common/components/Form";
+import Input from "../../../common/components/Input";
+import Button from "../../../common/components/Button";
+
+/**
+ * Sección de demostración de formularios
+ */
+const FormDemo: React.FC = () => (
+  <section className="space-y-4">
+    <h2 className="text-2xl font-bold">Formulario</h2>
+    <Form onSubmit={(e) => e.preventDefault()}>
+      <FormRow cols={2}>
+        <FormField label="Nombre" name="nombre">
+          <Input placeholder="Ingresa tu nombre" />
+        </FormField>
+        <FormField label="Correo" name="correo">
+          <Input type="email" placeholder="correo@ejemplo.com" />
+        </FormField>
+      </FormRow>
+      <FormRow cols={1}>
+        <FormField label="Mensaje" name="mensaje">
+          <textarea
+            className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-lg px-4 py-2.5 focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:outline-none"
+            placeholder="Escribe tu mensaje"
+            rows={4}
+          />
+        </FormField>
+      </FormRow>
+      <FormActions>
+        <Button type="submit">Enviar</Button>
+      </FormActions>
+    </Form>
+  </section>
+);
+
+export default FormDemo;

--- a/src/features/demo/components/TableDemo.tsx
+++ b/src/features/demo/components/TableDemo.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableHeadCell,
+} from "../../../common/components/Table";
+
+/**
+ * Sección de demostración de tablas
+ */
+const TableDemo: React.FC = () => (
+  <section className="space-y-4">
+    <h2 className="text-2xl font-bold">Tabla</h2>
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableHeadCell>Nombre</TableHeadCell>
+          <TableHeadCell>Correo</TableHeadCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <TableCell>Juan Pérez</TableCell>
+          <TableCell>juan@example.com</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Ana García</TableCell>
+          <TableCell>ana@example.com</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  </section>
+);
+
+export default TableDemo;

--- a/src/features/demo/components/TypographyDemo.tsx
+++ b/src/features/demo/components/TypographyDemo.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { H1, H2, H3, H4, H5, H6, Text } from "../../../common/components/Typography";
+
+/**
+ * Sección de demostración de tipografías
+ */
+const TypographyDemo: React.FC = () => (
+  <section className="space-y-2">
+    <H2>Tipografía</H2>
+
+    <div className="space-y-1">
+      <H1>Encabezado H1</H1>
+      <H2>Encabezado H2</H2>
+      <H3>Encabezado H3</H3>
+      <H4>Encabezado H4</H4>
+      <H5>Encabezado H5</H5>
+      <H6>Encabezado H6</H6>
+    </div>
+
+    <Text>
+      Este es un párrafo de texto de ejemplo siguiendo las pautas del sistema de diseño.
+    </Text>
+  </section>
+);
+
+export default TypographyDemo;

--- a/src/features/demo/components/index.ts
+++ b/src/features/demo/components/index.ts
@@ -1,0 +1,4 @@
+export { default as TypographyDemo } from "./TypographyDemo";
+export { default as ButtonDemo } from "./ButtonDemo";
+export { default as FormDemo } from "./FormDemo";
+export { default as TableDemo } from "./TableDemo";

--- a/src/features/demo/index.ts
+++ b/src/features/demo/index.ts
@@ -1,0 +1,3 @@
+export { default as DemoPage } from "./pages/DemoPage";
+export * from "./components";
+export { default as DemoLayout } from "./layouts/DemoLayout";

--- a/src/features/demo/layouts/DemoLayout.tsx
+++ b/src/features/demo/layouts/DemoLayout.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import Button from "../../../common/components/Button";
+import Container from "../../../common/components/Container";
+import {
+  TypographyDemo,
+  ButtonDemo,
+  FormDemo,
+  TableDemo,
+} from "../components";
+import { H1, H2 } from "../../../common/components/Typography";
+
+/**
+ * Layout de demostración que muestra tipografías, botones y componentes básicos.
+ */
+const DemoLayout: React.FC = () => {
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-900 text-white">
+      <header className="bg-gray-800 border-b border-gray-700 p-4">
+        <H1 className="mb-1">Título Principal</H1>
+        <H2 className="mb-4 text-gray-400">Subtítulo</H2>
+        <div className="space-x-2">
+          <Button variant="primary">Principal</Button>
+          <Button variant="secondary">Secundario</Button>
+          <Button variant="outline">Outline</Button>
+          <Button variant="text">Texto</Button>
+          <Button variant="danger">Peligro</Button>
+        </div>
+      </header>
+      <main className="flex-grow p-4">
+        <Container className="space-y-10">
+          <TypographyDemo />
+          <ButtonDemo />
+          <FormDemo />
+          <TableDemo />
+        </Container>
+      </main>
+      <footer className="bg-gray-800 border-t border-gray-700 p-4 text-center">
+        <p className="text-sm text-gray-400">
+          © {new Date().getFullYear()} Comunidad de Desarrollo de Software
+        </p>
+      </footer>
+    </div>
+  );
+};
+
+export default DemoLayout;

--- a/src/features/demo/pages/DemoPage.tsx
+++ b/src/features/demo/pages/DemoPage.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import DemoLayout from "../layouts/DemoLayout";
+
+const DemoPage: React.FC = () => <DemoLayout />;
+
+export default DemoPage;

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -11,4 +11,7 @@ export * from "./auth";
 // Exportar característica de usuarios
 export * from "./users";
 
+// Exportar página de demostración
+export * from "./demo";
+
 // Agregar aquí nuevas características a medida que se implementen


### PR DESCRIPTION
## Summary
- create `DemoLayout` component that displays typography, button variants, form fields, and a table
- simplify `DemoPage` to render the new layout
- export `DemoLayout` from the demo feature
- link Demo page in routes and navigation
- expand typography demo with all heading levels
- add reusable typography components and refactor demo to use them

## Testing
- `npm run lint` *(fails: 45 errors, 1 warning)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684728c6e8f083318425238a186b1abe