### PR TITLE
Improve API error typings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,10 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/src/common/utils/validations.ts
+++ b/src/common/utils/validations.ts
@@ -45,7 +45,7 @@ export const isValidUrl = (url: string): boolean => {
   try {
     new URL(url);
     return true;
-  } catch (error) {
+  } catch (_error) {
     return false;
   }
 };

--- a/src/core/api/client/axios.ts
+++ b/src/core/api/client/axios.ts
@@ -36,7 +36,7 @@ export class AxiosHttpClient implements IHttpClient {
    * @param config Configuración adicional
    * @returns Datos de la respuesta
    */
-  async get<T>(url: string, config?: any): Promise<T> {
+  async get<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
     const response = await this.instance.get<T, AxiosResponse<T>>(url, config);
     return response.data;
   }
@@ -48,8 +48,11 @@ export class AxiosHttpClient implements IHttpClient {
    * @param config Configuración adicional
    * @returns Datos de la respuesta
    */
-  async post<T>(url: string, data?: any, config?: any): Promise<T> {
-    console.log("post", url, data, config);
+  async post<T>(
+    url: string,
+    data?: object,
+    config?: AxiosRequestConfig
+  ): Promise<T> {
     const response = await this.instance.post<T, AxiosResponse<T>>(
       url,
       data,
@@ -65,7 +68,11 @@ export class AxiosHttpClient implements IHttpClient {
    * @param config Configuración adicional
    * @returns Datos de la respuesta
    */
-  async put<T>(url: string, data?: any, config?: any): Promise<T> {
+  async put<T>(
+    url: string,
+    data?: object,
+    config?: AxiosRequestConfig
+  ): Promise<T> {
     const response = await this.instance.put<T, AxiosResponse<T>>(
       url,
       data,
@@ -80,7 +87,7 @@ export class AxiosHttpClient implements IHttpClient {
    * @param config Configuración adicional
    * @returns Datos de la respuesta
    */
-  async delete<T>(url: string, config?: any): Promise<T> {
+  async delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
     const response = await this.instance.delete<T, AxiosResponse<T>>(
       url,
       config
@@ -95,7 +102,11 @@ export class AxiosHttpClient implements IHttpClient {
    * @param config Configuración adicional
    * @returns Datos de la respuesta
    */
-  async patch<T>(url: string, data?: any, config?: any): Promise<T> {
+  async patch<T>(
+    url: string,
+    data?: object,
+    config?: AxiosRequestConfig
+  ): Promise<T> {
     const response = await this.instance.patch<T, AxiosResponse<T>>(
       url,
       data,

--- a/src/core/api/interceptors/auth.ts
+++ b/src/core/api/interceptors/auth.ts
@@ -101,7 +101,7 @@ export const authResponseInterceptor = async (
 
     // Reintentar la petición original con el nuevo token
     return retryRequest(config);
-  } catch (refreshError) {
+  } catch (_refreshError) {
     // Error al refrescar el token, limpiar datos de autenticación
     authStorage.clearAuthData();
 

--- a/src/core/api/interceptors/error.ts
+++ b/src/core/api/interceptors/error.ts
@@ -7,6 +7,18 @@ import { formatError } from "../../utils/errors/errorHandler";
 import { createErrorFromStatus, ValidationError } from "../types/errors";
 import { HttpStatus } from "../config";
 
+/** Detalles que pueden venir en la respuesta de error de la API */
+interface ApiFieldError {
+  field: string;
+  errors: string[];
+}
+
+interface ApiErrorData {
+  message?: string;
+  errors?: ApiFieldError[];
+  fieldErrors?: Record<string, string>;
+}
+
 /**
  * Manejador de errores para peticiones
  * Se ejecuta cuando hay un error antes de enviar la petición
@@ -39,13 +51,13 @@ export const responseInterceptor = <T>(
  * Extraer errores específicos de campo del formato de API
  */
 function extractFieldErrors(
-  responseData: any
+  responseData: ApiErrorData
 ): Record<string, string> | undefined {
   const fieldErrors: Record<string, string> = {};
 
   // Formato 1: { errors: [{ field: string, errors: string[], value: any }] }
-  if (Array.isArray(responseData?.errors)) {
-    responseData.errors.forEach((errorInfo: any) => {
+  if (Array.isArray(responseData.errors)) {
+    responseData.errors.forEach((errorInfo) => {
       if (errorInfo.field && Array.isArray(errorInfo.errors)) {
         // Si el campo es 'general', asociarlo con un mensaje global
         if (errorInfo.field === "general" && errorInfo.errors.length > 0) {
@@ -59,10 +71,7 @@ function extractFieldErrors(
   }
 
   // Formato 2: { fieldErrors: { [field]: string } }
-  if (
-    responseData?.fieldErrors &&
-    typeof responseData.fieldErrors === "object"
-  ) {
+  if (responseData.fieldErrors && typeof responseData.fieldErrors === 'object') {
     Object.entries(responseData.fieldErrors).forEach(([field, message]) => {
       fieldErrors[field] = message as string;
     });
@@ -75,7 +84,9 @@ function extractFieldErrors(
  * Manejador general de errores para respuestas
  * Procesa todos los errores HTTP que no sean de autenticación (401)
  */
-export const responseErrorHandler = (error: AxiosError): Promise<never> => {
+export const responseErrorHandler = (
+  error: AxiosError<ApiErrorData>
+): Promise<never> => {
   // Si no tiene respuesta, rechazar con el error formateado
   if (!error.response) {
     return Promise.reject(formatError(error));
@@ -83,7 +94,7 @@ export const responseErrorHandler = (error: AxiosError): Promise<never> => {
 
   // Procesar según código de estado
   const status = error.response.status;
-  const responseData = error.response.data as Record<string, any>;
+  const responseData = error.response.data;
 
   // Extraer el mensaje del error del servidor
   const serverMessage =

--- a/src/core/api/types/index.ts
+++ b/src/core/api/types/index.ts
@@ -8,6 +8,8 @@ export * from "./responses";
 // Exportar tipos de solicitudes
 export * from "./requests";
 
+import { AxiosRequestConfig } from 'axios';
+
 // Exportar tipos de errores
 export * from "./errors";
 
@@ -22,7 +24,7 @@ export interface IHttpClient {
    * @param url Ruta del recurso
    * @param config Configuración opcional
    */
-  get<T>(url: string, config?: any): Promise<T>;
+  get<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
 
   /**
    * Realiza una solicitud POST
@@ -30,7 +32,11 @@ export interface IHttpClient {
    * @param data Datos a enviar
    * @param config Configuración opcional
    */
-  post<T>(url: string, data?: any, config?: any): Promise<T>;
+  post<T>(
+    url: string,
+    data?: object,
+    config?: AxiosRequestConfig
+  ): Promise<T>;
 
   /**
    * Realiza una solicitud PUT
@@ -38,14 +44,18 @@ export interface IHttpClient {
    * @param data Datos a enviar
    * @param config Configuración opcional
    */
-  put<T>(url: string, data?: any, config?: any): Promise<T>;
+  put<T>(
+    url: string,
+    data?: object,
+    config?: AxiosRequestConfig
+  ): Promise<T>;
 
   /**
    * Realiza una solicitud DELETE
    * @param url Ruta del recurso
    * @param config Configuración opcional
    */
-  delete<T>(url: string, config?: any): Promise<T>;
+  delete<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
 
   /**
    * Realiza una solicitud PATCH
@@ -53,7 +63,11 @@ export interface IHttpClient {
    * @param data Datos a enviar
    * @param config Configuración opcional
    */
-  patch<T>(url: string, data?: any, config?: any): Promise<T>;
+  patch<T>(
+    url: string,
+    data?: object,
+    config?: AxiosRequestConfig
+  ): Promise<T>;
 }
 
 /**

--- a/src/core/api/types/requests.ts
+++ b/src/core/api/types/requests.ts
@@ -72,7 +72,7 @@ export interface RequestOptions {
   /**
    * Funciones de transformación para la respuesta
    */
-  transformResponse?: ((data: any) => any)[];
+  transformResponse?: ((data: unknown) => unknown)[];
 
   /**
    * Opciones de caché

--- a/src/core/api/types/responses.ts
+++ b/src/core/api/types/responses.ts
@@ -36,7 +36,7 @@ export interface ApiErrorResponse {
   message: string;
   error: {
     code: string;
-    details?: Record<string, any>;
+    details?: Record<string, unknown>;
   };
   timestamp: string;
 }
@@ -53,15 +53,14 @@ export type EmptyResponse = ApiResponse<null>;
 /**
  * Respuesta de acción simplificada (éxito/fallo)
  */
-export interface ActionResponse extends ApiResponse<{ success: boolean }> {}
+export type ActionResponse = ApiResponse<{ success: boolean }>;
 
 /**
  * Respuesta con token para autenticación
  */
-export interface TokenResponse
-  extends ApiResponse<{
-    accessToken: string;
-    refreshToken: string;
-    expiresIn: number;
-    tokenType: string;
-  }> {}
+export type TokenResponse = ApiResponse<{
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  tokenType: string;
+}>;

--- a/src/core/auth/storage.ts
+++ b/src/core/auth/storage.ts
@@ -86,7 +86,7 @@ export class LocalStorageAuthHandler implements IAuthHandler {
   /**
    * Almacena los datos del usuario actual
    */
-  saveUserData(userData: any): void {
+  saveUserData<T extends Record<string, unknown>>(userData: T): void {
     if (userData) {
       localStorage.setItem(
         AUTH_STORAGE_KEYS.USER_DATA,

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -76,7 +76,7 @@ export interface User {
 export interface UserProfile extends User {
   phoneNumber?: string;
   bio?: string;
-  addresses?: any[];
+  addresses?: unknown[];
   socialLinks?: {
     github?: string;
     linkedin?: string;

--- a/src/core/utils/errors/errorHandler.ts
+++ b/src/core/utils/errors/errorHandler.ts
@@ -74,11 +74,11 @@ export function formatError(error: unknown): ApiError {
     const axiosError = error as {
       response?: {
         status?: number;
-        data?: any;
+        data?: unknown;
         statusText?: string;
       };
       message?: string;
-      request?: any;
+      request?: unknown;
     };
 
     // Error con respuesta del servidor

--- a/src/core/utils/validation/zodValidation.ts
+++ b/src/core/utils/validation/zodValidation.ts
@@ -46,7 +46,7 @@ export const name = z
  * @throws ValidationError si los datos no cumplen con el esquema
  */
 export function validateWithSchema<T, U>(
-  schema: z.ZodSchema<T, any, U>,
+  schema: z.ZodSchema<T, z.ZodTypeDef, U>,
   data: U
 ): T {
   try {

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -43,8 +43,22 @@ export interface IAuthService {
   verifyAuth(): Promise<{ isAuthenticated: boolean; user?: UserProfile }>;
 }
 
+// Tipo para el perfil de usuario proveniente de la API
+interface ApiUserProfile {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  fullName?: string;
+  avatar?: string;
+  roles: string[];
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // Mapper para convertir el perfil de usuario del API al modelo interno UserProfile
-const mapUserProfileFromApi = (apiData: any): UserProfile => {
+const mapUserProfileFromApi = (apiData: ApiUserProfile): UserProfile => {
   return {
     id: apiData.id,
     email: apiData.email,
@@ -294,7 +308,7 @@ class AuthService implements IAuthService {
         // Token expirado, intentar refresh
         try {
           await this.refreshToken();
-        } catch (error) {
+        } catch (_error) {
           // Error en refresh, usuario no autenticado
           return { isAuthenticated: false };
         }

--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -27,7 +27,7 @@ export interface User {
   isActive: boolean;
   avatar?: string;
   roles: string[];
-  addresses?: any[];
+  addresses?: unknown[];
   phoneNumber?: string | null;
   createdAt: string;
   updatedAt: string;
@@ -55,10 +55,10 @@ export interface ApiResponse<T> {
 }
 
 // Respuesta de login
-export interface LoginResponse extends ApiResponse<AuthTokens> {}
+export type LoginResponse = ApiResponse<AuthTokens>;
 
 // Respuesta del perfil
-export interface ProfileResponse extends ApiResponse<User> {}
+export type ProfileResponse = ApiResponse<User>;
 
 // Estado de autenticación
 export interface AuthState {

--- a/src/features/users/hooks/useUser.ts
+++ b/src/features/users/hooks/useUser.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import useUsersStore from "../store/usersStore";
-import { UserProfile } from "../types/userTypes";
+import { UserProfile, UserUpdateData } from "../types/userTypes";
 
 /**
  * Hook para acceder a los datos y funcionalidades de usuario
@@ -64,7 +64,8 @@ export const useUser = () => {
     fetchUsers,
     fetchUserById,
     getProfile,
-    updateProfile: (data: any) => updateUser(currentUser?.id || "", data),
+    updateProfile: (data: UserUpdateData) =>
+      updateUser(currentUser?.id || "", data),
     clearError,
     findUserById,
     searchUsers,

--- a/src/features/users/hooks/useUserForm.tsx
+++ b/src/features/users/hooks/useUserForm.tsx
@@ -87,7 +87,7 @@ export const useUserForm = (type: FormType, initialData?: UserProfile) => {
 
       setIsSubmitting(false);
       return true; // Éxito
-    } catch (error) {
+    } catch (_error) {
       setIsSubmitting(false);
       return false; // Error
     }

--- a/src/features/users/pages/ProfilePage.tsx
+++ b/src/features/users/pages/ProfilePage.tsx
@@ -8,6 +8,7 @@ import ProfileForm from "../components/ProfileForm";
 import ProfileInfo from "../components/ProfileInfo";
 import ProfileSidebar from "../components/ProfileSidebar";
 import { useUser } from "../hooks/useUser";
+import { UpdateProfileRequest } from "../types/userTypes";
 
 /**
  * Página de perfil de usuario que permite visualizar y editar información personal
@@ -16,7 +17,7 @@ const ProfilePage: React.FC = () => {
   const { currentUser, isLoading, error, updateProfile } = useUser();
   const [isEditing, setIsEditing] = useState(false);
 
-  const handleSubmit = async (profileData: any) => {
+  const handleSubmit = async (profileData: UpdateProfileRequest) => {
     await updateProfile(profileData);
     setIsEditing(false);
   };

--- a/src/features/users/types/userTypes.ts
+++ b/src/features/users/types/userTypes.ts
@@ -11,10 +11,10 @@ export interface ApiResponse<T> {
 }
 
 // Respuesta de perfil de usuario
-export interface UserProfileResponse extends ApiResponse<UserProfileDTO> {}
+export type UserProfileResponse = ApiResponse<UserProfileDTO>;
 
 // Respuesta de lista de usuarios
-export interface UsersListResponse extends ApiResponse<UserProfileDTO[]> {}
+export type UsersListResponse = ApiResponse<UserProfileDTO[]>;
 
 // Respuesta de eliminación o acciones booleanas
 export interface ActionResponse {
@@ -38,7 +38,7 @@ export interface UserProfileDTO {
   avatar?: string;
   bio?: string;
   roles: string[];
-  addresses?: any[];
+  addresses?: unknown[];
   phoneNumber?: string | null;
   createdAt: string;
   updatedAt: string;
@@ -66,7 +66,7 @@ export interface User {
   avatar?: string;
   bio?: string;
   roles: string[];
-  addresses?: any[];
+  addresses?: unknown[];
   phoneNumber?: string | null;
   createdAt: Date;
   updatedAt: Date;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -15,7 +15,7 @@ interface Window {
 
 // Declarar módulos para tipos de archivos que no tienen definiciones propias
 declare module '*.svg' {
-  import React = require('react');
+  import * as React from 'react';
   export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
   const src: string;
   export default src;


### PR DESCRIPTION
## Summary
- refine Axios interceptor types to avoid `unknown` usage in error handling
- define `ApiFieldError` and `ApiErrorData` interfaces

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684764e90d4883319e90036c8aaac56f